### PR TITLE
Remove unnecessary dependencies and config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,12 +4,6 @@ version = 0.1.0
 
 [options]
 include_package_data = True
-python_requires = >=3.7
-install_requires =
-  scitools-iris
-  xarray
-  pandas
-  geopandas
 
 packages = find:
 
@@ -19,10 +13,6 @@ packages = find:
 [options.packages.find]
 include = cap_sample_data
 
-[options.extras_require]
-dev =
-  pytest
-  flake8
 
 [flake8]
 # Slightly more generous line length, as used by black


### PR DESCRIPTION
There's no code in this repository, so it doesn't make sense to declare dependencies on large libraries like pandas and cartopy if there's nothing in the repo using them. Dependencies should be declared alongside the code that uses them (presumably in clean-air-project. I imagine this is just a copy & paste thing rather than intentional.